### PR TITLE
Check Zola base_url configuration for dynamic settings

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,15 @@ command = "zola build"
 
 [build.environment]
 ZOLA_VERSION = "0.19.2"
+
+# 正式環境 - 使用 config.toml 中設定的 base_url
+[context.production]
+command = "zola build"
+
+# PR 預覽環境 - 使用預覽 URL
+[context.deploy-preview]
+command = "zola build --base-url $DEPLOY_PRIME_URL"
+
+# 分支部署環境 - 使用分支專屬 URL
+[context.branch-deploy]
+command = "zola build --base-url $DEPLOY_PRIME_URL"


### PR DESCRIPTION
- 新增 deploy-preview 和 branch-deploy 環境設定
- PR 預覽和分支部署現在會使用 $DEPLOY_PRIME_URL 作為 base_url
- 正式環境繼續使用 config.toml 中的 base_url
- 這樣可以確保 PR 預覽中的連結指向正確的預覽 URL，而不是正式環境