### PR TITLE
Add wisdom article: AI Agents 正在吞噬 SaaS

### DIFF
--- a/content/wisdom/articles/ai-agents-eat-saas/index.md
+++ b/content/wisdom/articles/ai-agents-eat-saas/index.md
@@ -13,11 +13,11 @@ tags = [ "generative-ai", "saas",]
 
 文章：[AI Agents are Starting to Eat SaaS](https://martinalderson.com/posts/ai-agents-are-starting-to-eat-saas/)
 
-過去 15 年是見證 Software eat the world 的發生，隨著近年 LLM 與 AI Agents 的成熟，世界將開始轉變成 Agents eat SaaS。
+過去 15 年是見證 [Software eats the world](https://a16z.com/why-software-is-eating-the-world/) 的發生，隨著近年 LLM 與 AI Agents 的成熟，世界將開始轉變成 Agents eat SaaS。
 
 客製化工具將大大減少 SaaS 服務的需求。不需要為了少數特定功能，買擁有很多用不到的功能的 SaaS 服務，也不需要期待 SaaS 開發者在多方需求下能實作你需要的新功能。
 
-過往的客製化工具依賴開發工程師的知識，但現在有了不會離職的 AI Agents，對於工具細節的解釋及修改比過往來得容易很多。當然維運的需求會提升，所以作者預測對於 SRE 或 DevOps 角色的需求將會提升，或是會產生新的職位也說不定。
+過往的客製化工具依賴開發工程師的知識，但現在有了不會離職的 AI Agents，對於工具細節的解釋及修改比過往來得容易很多。當然維運的需求會提升，所以作者預測對於 SRE 或 DevOps 角色的需求將會增加，甚至產生新的職位。
 
 但還是會有擁有護城河的 SaaS 服務存在：
 - 有高 SLA 需求的服務。

--- a/content/wisdom/articles/ai-agents-eat-saas/index.md
+++ b/content/wisdom/articles/ai-agents-eat-saas/index.md
@@ -1,0 +1,29 @@
++++
+title = "AI Agents 正在吞噬 SaaS"
+date = 2025-12-28
+description = "隨著 LLM 與 AI Agents 的成熟，世界將從 Software eat the world 轉變為 Agents eat SaaS。探討客製化工具如何取代 SaaS，以及哪些 SaaS 服務仍具有護城河。"
+
+[taxonomies]
+categories = [ "閱讀筆記",]
+tags = [ "generative-ai", "saas",]
+
++++
+
+創作者：[Martin Alderson](https://martinalderson.com/)
+
+文章：[AI Agents are Starting to Eat SaaS](https://martinalderson.com/posts/ai-agents-are-starting-to-eat-saas/)
+
+過去 15 年是見證 Software eat the world 的發生，隨著近年 LLM 與 AI Agents 的成熟，世界將開始轉變成 Agents are going to eat SaaS。
+
+客製化工具將大大減少 SaaS 服務的需求。不需要為了少數特定功能，買擁有很多用不到的功能的 SaaS 服務，也不需要期待 SaaS 開發者在多方需求下能實作你需要的新功能。
+
+過往的客製化工具依賴開發工程師的知識，但現在有了不會離職的 AI Agents，對於工具細節的解釋及修改比過往來得容易很多。當然維運的需求會提升，所以作者預測對於 SRE 或 DevOps 角色的需求將會提升，或是會產生新的職位也說不定。
+
+但還是會有擁有護城河的 SaaS 服務存在：
+- 有高 SLA 需求的服務。
+- 金流相關服務。
+- 資料湖等擁有大型資料的服務。
+- 具有網路效應（Network Effect）的服務，如 Slack。
+- 擁有強大生態系或眾多 Plugin 的服務。
+- 擁有高價值資料集的服務，甚至未來能讓 AI Agent 以不同方式接上。
+- 監管需求相關服務。

--- a/content/wisdom/articles/ai-agents-eat-saas/index.md
+++ b/content/wisdom/articles/ai-agents-eat-saas/index.md
@@ -13,7 +13,7 @@ tags = [ "generative-ai", "saas",]
 
 文章：[AI Agents are Starting to Eat SaaS](https://martinalderson.com/posts/ai-agents-are-starting-to-eat-saas/)
 
-過去 15 年是見證 Software eat the world 的發生，隨著近年 LLM 與 AI Agents 的成熟，世界將開始轉變成 Agents are going to eat SaaS。
+過去 15 年是見證 Software eat the world 的發生，隨著近年 LLM 與 AI Agents 的成熟，世界將開始轉變成 Agents eat SaaS。
 
 客製化工具將大大減少 SaaS 服務的需求。不需要為了少數特定功能，買擁有很多用不到的功能的 SaaS 服務，也不需要期待 SaaS 開發者在多方需求下能實作你需要的新功能。
 


### PR DESCRIPTION
新增一篇 wisdom article，探討 AI Agents 如何改變 SaaS 產業格局。
文章分析了客製化工具取代傳統 SaaS 的趨勢，以及仍具護城河的 SaaS 類型。