### PR TITLE
Add dark mode support and redesign navigation

### DIFF
--- a/static/js/theme-toggle.js
+++ b/static/js/theme-toggle.js
@@ -1,0 +1,85 @@
+/**
+ * Theme toggle: supports light / dark mode
+ * - Default: follows system prefers-color-scheme (no data-theme set on <html>)
+ * - After user manually toggles: saves preference to localStorage
+ * - Utterances comment iframe theme is updated on switch
+ */
+
+(function () {
+  const STORAGE_KEY = "color-theme";
+  const DARK = "dark";
+  const LIGHT = "light";
+
+  function getSystemTheme() {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? DARK
+      : LIGHT;
+  }
+
+  function getActiveTheme() {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === DARK || saved === LIGHT) return saved;
+    return getSystemTheme();
+  }
+
+  function applyTheme(theme) {
+    const html = document.documentElement;
+    if (theme === DARK) {
+      html.setAttribute("data-theme", DARK);
+    } else {
+      html.setAttribute("data-theme", LIGHT);
+    }
+    updateToggleUI(theme);
+    updateUtterancesTheme(theme);
+  }
+
+  function updateToggleUI(theme) {
+    const btn = document.getElementById("theme-toggle-btn");
+    if (!btn) return;
+    if (theme === DARK) {
+      btn.setAttribute("title", "切換為淺色模式");
+      btn.innerHTML = '<span aria-hidden="true">☀️</span> <span class="theme-toggle-label">淺色</span>';
+    } else {
+      btn.setAttribute("title", "切換為深色模式");
+      btn.innerHTML = '<span aria-hidden="true">🌙</span> <span class="theme-toggle-label">深色</span>';
+    }
+  }
+
+  function updateUtterancesTheme(theme) {
+    const iframe = document.querySelector(".utterances-frame");
+    if (!iframe) return;
+    const utterancesTheme = theme === DARK ? "github-dark" : "github-light";
+    iframe.contentWindow.postMessage(
+      { type: "set-theme", theme: utterancesTheme },
+      "https://utteranc.es"
+    );
+  }
+
+  function toggleTheme() {
+    const current = getActiveTheme();
+    const next = current === DARK ? LIGHT : DARK;
+    localStorage.setItem(STORAGE_KEY, next);
+    applyTheme(next);
+  }
+
+  // Apply theme immediately on load (before DOMContentLoaded to avoid flash)
+  applyTheme(getActiveTheme());
+
+  document.addEventListener("DOMContentLoaded", function () {
+    const btn = document.getElementById("theme-toggle-btn");
+    if (btn) {
+      btn.addEventListener("click", toggleTheme);
+    }
+    // Re-sync UI after DOM is ready
+    updateToggleUI(getActiveTheme());
+
+    // Listen for system preference changes (if user hasn't manually set a preference)
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .addEventListener("change", function (e) {
+        if (!localStorage.getItem(STORAGE_KEY)) {
+          applyTheme(e.matches ? DARK : LIGHT);
+        }
+      });
+  });
+})();

--- a/static/js/theme-toggle.js
+++ b/static/js/theme-toggle.js
@@ -34,15 +34,15 @@
   }
 
   function updateToggleUI(theme) {
-    const btn = document.getElementById("theme-toggle-btn");
-    if (!btn) return;
-    if (theme === DARK) {
-      btn.setAttribute("title", "切換為淺色模式");
-      btn.innerHTML = '<span aria-hidden="true">☀️</span> <span class="theme-toggle-label">淺色</span>';
-    } else {
-      btn.setAttribute("title", "切換為深色模式");
-      btn.innerHTML = '<span aria-hidden="true">🌙</span> <span class="theme-toggle-label">深色</span>';
-    }
+    document.querySelectorAll(".theme-toggle").forEach(function (btn) {
+      if (theme === DARK) {
+        btn.setAttribute("title", "切換為淺色模式");
+        btn.innerHTML = '<span aria-hidden="true">☀️</span> <span class="theme-toggle-label">淺色</span>';
+      } else {
+        btn.setAttribute("title", "切換為深色模式");
+        btn.innerHTML = '<span aria-hidden="true">🌙</span> <span class="theme-toggle-label">深色</span>';
+      }
+    });
   }
 
   function updateUtterancesTheme(theme) {
@@ -66,10 +66,10 @@
   applyTheme(getActiveTheme());
 
   document.addEventListener("DOMContentLoaded", function () {
-    const btn = document.getElementById("theme-toggle-btn");
-    if (btn) {
+    // Attach click to all toggle buttons (mobile topbar + desktop nav)
+    document.querySelectorAll(".theme-toggle").forEach(function (btn) {
       btn.addEventListener("click", toggleTheme);
-    }
+    });
     // Re-sync UI after DOM is ready
     updateToggleUI(getActiveTheme());
 

--- a/static/site/styles/site.css
+++ b/static/site/styles/site.css
@@ -219,12 +219,11 @@ article h1 {
 }
 
 article h1::before {
-  /* This is necessary for the pseudo-element to be generated */
   content: "";
   position: absolute;
   width: 10px;
   height: 1.6rem;
-  background-color: var(--colors-navbar);
+  background-color: var(--colors-primary);
   top: 60%;
   left: 0;
   transform: translateY(-50%);
@@ -911,6 +910,11 @@ tr:first-child th {
   background: rgba(255, 255, 255, 0.15);
   color: var(--colors-text-light);
   text-decoration: none;
+}
+
+/* Push theme toggle + search to the far right */
+.site-nav__theme-toggle {
+  margin-left: auto;
 }
 
 /* Search */

--- a/static/site/styles/site.css
+++ b/static/site/styles/site.css
@@ -83,6 +83,8 @@ th {
 html {
   font-size: 0.9rem;
   box-sizing: border-box;
+
+  /* === Light mode (default) === */
   --colors-text: rgba(0, 0, 0, 0.8);
   --colors-text-light: rgba(255, 247, 247, 1);
   --colors-muted: #b3b3b1;
@@ -97,12 +99,92 @@ html {
   --colors-header: #003c6d;
   --colors-header-text: #ffffff;
   --colors-border: #e9edf0;
+  --colors-inline-code-bg: rgba(39, 133, 184, 0.12);
+  --colors-inline-code-border: rgba(39, 133, 184, 0.3);
+  --colors-inline-code-text: #2d7ab8;
+  --colors-card-bg: #ffffff;
+  --colors-card-text: #2c3e50;
+  --colors-card-hover: #e74c3c;
+  --colors-link: #000000;
+  --colors-link-visited: #013127;
+  --colors-table-odd: rgba(187, 222, 214, 1);
+  --colors-table-even: rgba(138, 198, 209, 1);
+  --colors-table-hover: #e9edf0;
+  --colors-theme-toggle-bg: rgba(255,255,255,0.15);
+  --colors-theme-toggle-text: #ffffff;
+}
+
+/* === Dark mode via data-theme attribute === */
+[data-theme="dark"] {
+  --colors-text: rgba(220, 228, 240, 0.92);
+  --colors-text-light: rgba(255, 247, 247, 1);
+  --colors-muted: #6b7280;
+  --colors-primary: #7fa3e8;
+  --colors-divider: #2a3650;
+  --colors-primary-light: #9fb8ee;
+  --colors-code-background: rgba(39, 133, 184, 0.35);
+  --colors-navbar: rgba(14, 30, 54, 1);
+  --colors-background: #0f1623;
+  --colors-article: #141c2b;
+  --colors-special: rgba(8, 255, 200, 1);
+  --colors-header: #1a3356;
+  --colors-header-text: #dce4f0;
+  --colors-border: #2a3650;
+  --colors-inline-code-bg: rgba(127, 163, 232, 0.12);
+  --colors-inline-code-border: rgba(127, 163, 232, 0.25);
+  --colors-inline-code-text: #93b4ee;
+  --colors-card-bg: #1e2a3d;
+  --colors-card-text: #dce4f0;
+  --colors-card-hover: #7fa3e8;
+  --colors-link: #dce4f0;
+  --colors-link-visited: #a3c4e8;
+  --colors-table-odd: rgba(30, 52, 80, 1);
+  --colors-table-even: rgba(22, 40, 64, 1);
+  --colors-table-hover: #2a3a56;
+  --colors-theme-toggle-bg: rgba(255,255,255,0.1);
+  --colors-theme-toggle-text: #ffffff;
+}
+
+/* === Auto dark mode based on system preference (when no manual override) === */
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) {
+    --colors-text: rgba(220, 228, 240, 0.92);
+    --colors-text-light: rgba(255, 247, 247, 1);
+    --colors-muted: #6b7280;
+    --colors-primary: #7fa3e8;
+    --colors-divider: #2a3650;
+    --colors-primary-light: #9fb8ee;
+    --colors-code-background: rgba(39, 133, 184, 0.35);
+    --colors-navbar: rgba(14, 30, 54, 1);
+    --colors-background: #0f1623;
+    --colors-article: #141c2b;
+    --colors-special: rgba(8, 255, 200, 1);
+    --colors-header: #1a3356;
+    --colors-header-text: #dce4f0;
+    --colors-border: #2a3650;
+    --colors-inline-code-bg: rgba(127, 163, 232, 0.12);
+    --colors-inline-code-border: rgba(127, 163, 232, 0.25);
+    --colors-inline-code-text: #93b4ee;
+    --colors-card-bg: #1e2a3d;
+    --colors-card-text: #dce4f0;
+    --colors-card-hover: #7fa3e8;
+    --colors-link: #dce4f0;
+    --colors-link-visited: #a3c4e8;
+    --colors-table-odd: rgba(30, 52, 80, 1);
+    --colors-table-even: rgba(22, 40, 64, 1);
+    --colors-table-hover: #2a3a56;
+    --colors-theme-toggle-bg: rgba(255,255,255,0.1);
+    --colors-theme-toggle-text: #ffffff;
+  }
 }
 
 body {
-  font-family: Menlo, "PT Mono", "Arial", "Helvetica", "Helvetica Neue", "Noto Sans TC", "PingFang TC", "PingFang SC", sans-serif, Georgia;
-  color: var(--color-text);
+  font-family: "Noto Serif TC", "Noto Sans TC", "PingFang TC", "PingFang SC", "Arial", "Helvetica", "Helvetica Neue", sans-serif;
+  color: var(--colors-text);
   background-color: var(--colors-background);
+  /* Offset for fixed navbar */
+  padding-top: 56px;
+  transition: background-color 0.25s ease, color 0.25s ease;
 }
 
 #root {
@@ -116,6 +198,7 @@ h2,
 h3,
 h4,
 h5 {
+  font-family: "Noto Sans TC", "PingFang TC", "PingFang SC", "Arial", sans-serif;
   padding-top: 1.4rem;
   padding-bottom: 0.4rem;
   margin-bottom: 0.2rem;
@@ -223,9 +306,9 @@ code {
   font-size: 0.92rem;
   border-radius: 6px;
   padding: 0.2rem 0.5rem;
-  background: linear-gradient(135deg, rgba(39, 133, 184, 0.15) 0%, rgba(39, 133, 184, 0.25) 100%);
-  border: 1px solid rgba(39, 133, 184, 0.3);
-  color: #2d7ab8;
+  background: var(--colors-inline-code-bg);
+  border: 1px solid var(--colors-inline-code-border);
+  color: var(--colors-inline-code-text);
   font-weight: 500;
 }
 
@@ -350,14 +433,14 @@ ul {
 }
 
 a:link {
-  color: #000000;
+  color: var(--colors-link);
 }
 
 a:visited {
   -webkit-transition: color 200ms ease;
   transition: color 200ms ease;
   text-decoration: none;
-  color: #013127;
+  color: var(--colors-link-visited);
   text-decoration-thickness: 0.1rem;
 }
 
@@ -416,47 +499,12 @@ a.muted,
   padding-bottom: 1.4rem;
 }
 
-.navbar-menu {
-  display: inline-block;
-  font-size: 1.2rem;
-  line-height: 1.4rem;
-  padding-left: 8px;
-  position: relative;
-  top: -1.5px;
-  vertical-align: middle;
-  color: rgb(0, 0, 0);
-  white-space: nowrap;
-  margin-top: 0.5rem;
-  margin-bottom: 1.0rem;
-}
-
-.navbar-a:link {
-  display: flex;
-  align-items: center;
-  color: var(--colors-text-light);
-  text-decoration: none;
-  padding-left: 12px;
-  font-size: 16px;
-}
-
-.navbar-top {
-  font-size: 1.1rem;
-  position: fixed;
-  display: flex;
-  justify-content: space-between;
-  height: 8vh;
-  width: 100%;
-  padding: 1.1rem;
-  align-items: center;
-  border-bottom: 3px solid #e9edf0;
-  color: var(--colors-text-light);
-  z-index: 1100;
-  background-color: var(--colors-navbar);
-}
+/* Legacy navbar classes removed – replaced by .site-nav */
 
 article {
   padding-bottom: 0.2rem;
   background-color: var(--colors-background);
+  transition: background-color 0.25s ease;
 }
 
 article:last-of-type {
@@ -554,7 +602,8 @@ td:last-child {
 }
 
 tr:nth-child(even) td {
-  background-color: rgba(226, 232, 240, 0.3);
+  background-color: var(--colors-divider);
+  opacity: 0.6;
 }
 
 tr:first-child th {
@@ -623,6 +672,16 @@ tr:first-child th {
   vertical-align: middle;
 }
 
+[data-theme="dark"] .external-link::after {
+  filter: invert(0.7) brightness(1.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) .external-link::after {
+    filter: invert(0.7) brightness(1.5);
+  }
+}
+
 @media (min-width: 767px) {
   #root {
     display: flex;
@@ -633,7 +692,7 @@ tr:first-child th {
     padding-left: 8rem;
     padding-right: 8rem;
     background-color: var(--colors-article);
-    padding-top: 4.8rem;
+    padding-top: 2rem;
     padding-bottom: 2.8rem;
     max-width: 64rem;
     min-width: 52rem;
@@ -659,7 +718,7 @@ tr:first-child th {
   .sidebar {
     position: sticky;
     border-top: none;
-    top: 60px;
+    top: 8px;
     z-index: 1;
     height: 100vh;
     overflow-y: auto;
@@ -704,30 +763,330 @@ tr:first-child th {
 
   .reading-notes-table th {
     font-weight: 600;
-    background-color: #003c6d;
-    color: #ffffff;
+    background-color: var(--colors-header);
+    color: var(--colors-header-text);
   }
 
   .reading-notes-table tbody tr:nth-child(odd) {
-    background-color: rgba(187, 222, 214, 1);
+    background-color: var(--colors-table-odd);
   }
 
   .reading-notes-table tbody tr:nth-child(even) {
-    background-color: rgba(138, 198, 209, 1);
+    background-color: var(--colors-table-even);
   }
 
   .reading-notes-table tbody tr:hover {
-    background-color: #e9edf0;
+    background-color: var(--colors-table-hover);
     cursor: pointer;
   }
 }
+
+/* #region Navigation */
+
+.site-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1100;
+  background-color: var(--colors-navbar);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  font-family: "Noto Sans TC", "PingFang TC", "Arial", sans-serif;
+  transition: background-color 0.25s ease;
+}
+
+.site-nav__topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1rem;
+  height: 56px;
+}
+
+.site-nav__logo {
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+.site-nav__logo img {
+  display: block;
+  width: 40px;
+  height: 40px;
+  margin: 0;
+  border-radius: 6px;
+}
+
+.site-nav__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* Desktop nav links */
+.site-nav__links {
+  display: none; /* hidden on mobile by default */
+}
+
+.site-nav__link {
+  color: var(--colors-text-light);
+  text-decoration: none;
+  padding: 0.5rem 0.8rem;
+  font-size: 1rem;
+  border-radius: 4px;
+  transition: background 0.15s ease;
+  white-space: nowrap;
+}
+
+.site-nav__link:link,
+.site-nav__link:visited {
+  color: var(--colors-text-light);
+  text-decoration: none;
+}
+
+.site-nav__link:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: var(--colors-text-light);
+  text-decoration: none;
+}
+
+/* Dropdown */
+.site-nav__dropdown {
+  position: relative;
+}
+
+.site-nav__dropdown-btn {
+  background: none;
+  border: none;
+  color: var(--colors-text-light);
+  padding: 0.5rem 0.8rem;
+  font-size: 1rem;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.15s ease;
+  white-space: nowrap;
+  font-family: inherit;
+}
+
+.site-nav__dropdown-btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.site-nav__dropdown-menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  min-width: 140px;
+  background: var(--colors-navbar);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  z-index: 200;
+  overflow: hidden;
+}
+
+.site-nav__dropdown:hover .site-nav__dropdown-menu,
+.site-nav__dropdown-menu:hover {
+  display: block;
+}
+
+.site-nav__dropdown-item {
+  display: block;
+  padding: 0.5rem 1rem;
+  color: var(--colors-text-light);
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: background 0.15s ease;
+  white-space: nowrap;
+}
+
+.site-nav__dropdown-item:link,
+.site-nav__dropdown-item:visited {
+  color: var(--colors-text-light);
+  text-decoration: none;
+}
+
+.site-nav__dropdown-item:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: var(--colors-text-light);
+  text-decoration: none;
+}
+
+/* Search */
+.site-nav__search {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 0.5rem;
+}
+
+.site-nav__search-input {
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--colors-text-light);
+  font-size: 0.9rem;
+  width: 130px;
+  font-family: inherit;
+  outline: none;
+}
+
+.site-nav__search-input::placeholder {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.site-nav__search-input:focus {
+  background: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.site-nav__search-btn {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: var(--colors-text-light);
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background 0.15s ease;
+}
+
+.site-nav__search-btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+/* Hamburger button */
+.hamburger-btn {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 4px;
+  transition: background 0.15s ease;
+}
+
+.hamburger-btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.hamburger-line {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: var(--colors-text-light);
+  border-radius: 2px;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+/* Hamburger open state */
+.hamburger-btn.is-open .hamburger-line:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+.hamburger-btn.is-open .hamburger-line:nth-child(2) {
+  opacity: 0;
+}
+.hamburger-btn.is-open .hamburger-line:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
+/* Mobile nav open state */
+.site-nav__links.is-open {
+  display: flex;
+  flex-direction: column;
+  padding: 0.5rem 1rem 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  gap: 2px;
+}
+
+/* Desktop layout */
+@media (min-width: 768px) {
+  .site-nav__topbar {
+    height: 56px;
+  }
+
+  .hamburger-btn {
+    display: none;
+  }
+
+  .site-nav__links {
+    display: flex !important;
+    flex-direction: row;
+    align-items: center;
+    padding: 0 1rem 0 0.5rem;
+    gap: 2px;
+    border-top: none;
+    height: 44px;
+  }
+
+  .site-nav {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    height: 56px;
+    padding: 0;
+  }
+
+  .site-nav__topbar {
+    padding: 0 0 0 1rem;
+    flex-shrink: 0;
+    height: 56px;
+    gap: 0;
+  }
+
+  .site-nav__actions {
+    gap: 10px;
+  }
+
+  .site-nav__links.is-open {
+    flex-direction: row;
+    padding: 0;
+    border-top: none;
+  }
+}
+
+/* #endregion */
+
+/* #region Theme Toggle */
+
+.theme-toggle {
+  background: var(--colors-theme-toggle-bg);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: var(--colors-theme-toggle-text);
+  border-radius: 20px;
+  padding: 5px 12px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  transition: background 0.2s ease, transform 0.1s ease;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.25);
+  transform: translateY(-1px);
+}
+
+.theme-toggle:active {
+  transform: translateY(0);
+}
+
+/* #endregion */
 
 /* #region Recommended Articles */
 
 .recommended-article {
   width: 100%;
   max-width: 300px;
-  background: #ffffff;
+  background: var(--colors-card-bg);
   border-radius: 8px;
   overflow: hidden;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
@@ -784,13 +1143,13 @@ tr:first-child th {
 }
 
 .article-title a {
-  color: #2c3e50;
+  color: var(--colors-card-text);
   text-decoration: none;
   transition: color 0.3s ease;
 }
 
 .article-title a:hover {
-  color: #e74c3c;
+  color: var(--colors-card-hover);
 }
 
 .cards-container {

--- a/static/site/styles/site.css
+++ b/static/site/styles/site.css
@@ -912,8 +912,14 @@ tr:first-child th {
   text-decoration: none;
 }
 
-/* Push theme toggle + search to the far right */
+/* Mobile-only toggle: visible on mobile, hidden on desktop */
+.theme-toggle--mobile {
+  display: flex;
+}
+
+/* Desktop toggle inside nav links: hidden on mobile, pushed right on desktop */
 .site-nav__theme-toggle {
+  display: none;
   margin-left: auto;
 }
 
@@ -1046,6 +1052,15 @@ tr:first-child th {
 
   .site-nav__actions {
     gap: 10px;
+  }
+
+  /* Swap toggle visibility on desktop */
+  .theme-toggle--mobile {
+    display: none;
+  }
+
+  .site-nav__theme-toggle {
+    display: flex;
   }
 
   .site-nav__links.is-open {

--- a/static/site/styles/site.css
+++ b/static/site/styles/site.css
@@ -913,12 +913,12 @@ tr:first-child th {
 }
 
 /* Mobile-only toggle: visible on mobile, hidden on desktop */
-.theme-toggle--mobile {
+.theme-toggle.theme-toggle--mobile {
   display: flex;
 }
 
 /* Desktop toggle inside nav links: hidden on mobile, pushed right on desktop */
-.site-nav__theme-toggle {
+.theme-toggle.site-nav__theme-toggle {
   display: none;
   margin-left: auto;
 }
@@ -1055,11 +1055,11 @@ tr:first-child th {
   }
 
   /* Swap toggle visibility on desktop */
-  .theme-toggle--mobile {
+  .theme-toggle.theme-toggle--mobile {
     display: none;
   }
 
-  .site-nav__theme-toggle {
+  .theme-toggle.site-nav__theme-toggle {
     display: flex;
   }
 

--- a/static/site/styles/site.css
+++ b/static/site/styles/site.css
@@ -1020,6 +1020,7 @@ tr:first-child th {
 
   .site-nav__links {
     display: flex !important;
+    flex: 1;
     flex-direction: row;
     align-items: center;
     padding: 0 1rem 0 0.5rem;

--- a/templates/base.html
+++ b/templates/base.html
@@ -62,6 +62,9 @@
               height="48" alt="針織拙見 Logo">
           </a>
           <div class="site-nav__actions">
+            <button class="theme-toggle theme-toggle--mobile" aria-label="切換顯示主題">
+              🌙 深色
+            </button>
             <button id="hamburger-btn" class="hamburger-btn" aria-label="開啟選單" aria-expanded="false" aria-controls="mobile-nav">
               <span class="hamburger-line"></span>
               <span class="hamburger-line"></span>

--- a/templates/base.html
+++ b/templates/base.html
@@ -62,9 +62,6 @@
               height="48" alt="針織拙見 Logo">
           </a>
           <div class="site-nav__actions">
-            <button id="theme-toggle-btn" class="theme-toggle" aria-label="切換顯示主題">
-              🌙 深色
-            </button>
             <button id="hamburger-btn" class="hamburger-btn" aria-label="開啟選單" aria-expanded="false" aria-controls="mobile-nav">
               <span class="hamburger-line"></span>
               <span class="hamburger-line"></span>
@@ -91,6 +88,9 @@
           </div>
           <a class="site-nav__link" href="/about/">關於</a>
           <a class="site-nav__link" href="/now/">Now Page</a>
+          <button id="theme-toggle-btn" class="theme-toggle site-nav__theme-toggle" aria-label="切換顯示主題">
+            🌙 深色
+          </button>
           <form action="https://www.google.com/search" id="search" method="get" target="_blank" class="site-nav__search">
             <input type="text" name="q" placeholder="搜尋..." class="site-nav__search-input" aria-label="搜尋">
             <input type="hidden" name="sitesearch" value="{{ config.base_url }}">

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,59 +33,73 @@
     <meta property="og:description" content="{{ description }}" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="{{ sns_image }}" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="{{ image_width }}" />
+    <meta property="og:image:width" content="{{ image_width }}" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:url" content="{{ current_url }}" />
     <meta name="twitter:card" content="{{ twitter_card }}" />
-    <script src="{{ get_url(path="js/tablesort.min.js", cachebust=true) }}"></script>
-    <script src="{{ get_url(path="js/copy-code-button.js") | safe }}"></script>
+    <script src="{{ get_url(path="js/tablesort.min.js", cachebust=true) }}" defer></script>
+    <script src="{{ get_url(path="js/copy-code-button.js") | safe }}" defer></script>
     <link rel="icon" href="{{ get_url(path="images/favicon.ico", cachebust=true) }}" type="image/x-icon" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600&family=Noto+Serif+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ get_url(path="site/styles/w3.css", trailing_slash=false, cachebust=true) | safe }}">
     <link rel="stylesheet"
       href="{{ get_url(path="site/styles/site.css", trailing_slash=false, cachebust=true) | safe }}">
     <link rel="alternate" type="application/atom+xml" href="{{ config.base_url }}/atom.xml"
       title="{{ config.title }}" />
+    <!-- Theme toggle: runs before paint to prevent flash of wrong theme -->
+    <script src="{{ get_url(path="js/theme-toggle.js", cachebust=true) | safe }}"></script>
   </head>
 
   <body>
     <header>
-      <nav class="w3-bar w3-teal">
-        <a class="w3-bar-item w3-mobile w3-teal" href="{{ config.base_url }}">
-          <img src="{{ get_url(path="images/logo_630.webp", trailing_slash=false, cachebust=true) | safe}}" width="60"
-            height="60" alt="Logo">
-        </a>
-        <a class="w3-bar-item w3-button w3-mobile w3-hover-green w3-large w3-teal w3-padding-24"
-          href="/reading-notes/">閱讀筆記</a>
-        <a class="w3-bar-item w3-button w3-mobile w3-hover-green w3-large w3-teal w3-padding-24" href="/blog/">部落格文章</a>
-        <div class="w3-dropdown-hover w3-mobile">
-          <button class="w3-button w3-large w3-hover-green w3-teal w3-padding-24">眾人的智慧</button>
-          <div class="w3-dropdown-content w3-bar-block">
-            <a class="w3-bar-item w3-button w3-mobile w3-hover-green" href="/wisdom/articles/">文章</a>
-            <a class="w3-bar-item w3-button w3-mobile w3-hover-green" href="/wisdom/videos/">影片</a>
-            <a class="w3-bar-item w3-button w3-mobile w3-hover-green" href="/wisdom/podcasts/">Podcast</a>
-            <a class="w3-bar-item w3-button w3-mobile w3-hover-green" href="/wisdom/lists/">清單</a>
-            <a class="w3-bar-item w3-button w3-mobile w3-hover-green" href="/wisdom/mental-models/">思維模型</a>
-            <a class="w3-bar-item w3-button w3-mobile w3-hover-green" href="/wisdom/methods/">方法</a>
-            <a class="w3-bar-item w3-button w3-mobile w3-hover-green" href="/wisdom/strategies/">策略</a>
-            <a class="w3-bar-item w3-button w3-mobile w3-hover-green" href="/wisdom/templates/">範本</a>
+      <nav class="site-nav" role="navigation" aria-label="主要導航">
+        <!-- Top bar: always visible -->
+        <div class="site-nav__topbar">
+          <a class="site-nav__logo" href="{{ config.base_url }}" aria-label="回首頁">
+            <img src="{{ get_url(path="images/logo_630.webp", trailing_slash=false, cachebust=true) | safe}}" width="48"
+              height="48" alt="針織拙見 Logo">
+          </a>
+          <div class="site-nav__actions">
+            <button id="theme-toggle-btn" class="theme-toggle" aria-label="切換顯示主題">
+              🌙 深色
+            </button>
+            <button id="hamburger-btn" class="hamburger-btn" aria-label="開啟選單" aria-expanded="false" aria-controls="mobile-nav">
+              <span class="hamburger-line"></span>
+              <span class="hamburger-line"></span>
+              <span class="hamburger-line"></span>
+            </button>
           </div>
         </div>
-        <a class="w3-bar-item w3-button w3-mobile w3-hover-green w3-large w3-teal w3-padding-24" href="/about/">關於</a>
-        <a class="w3-bar-item w3-button w3-mobile w3-hover-green w3-large w3-teal w3-padding-24" href="/now/">Now
-          Page</a>
-        <div class="w3-bar-item w3-right w3-padding-24">
-          <form action="https://www.google.com/search" id="search" method="get" target="_blank">
-            <input type="text" name="q" placeholder="搜尋..." class="w3-input w3-bar-item"
-              style="display:inline-block; width:auto;">
+        <!-- Nav links: horizontal on desktop, collapsible on mobile -->
+        <div id="mobile-nav" class="site-nav__links">
+          <a class="site-nav__link" href="/reading-notes/">閱讀筆記</a>
+          <a class="site-nav__link" href="/blog/">部落格文章</a>
+          <div class="site-nav__dropdown">
+            <button class="site-nav__dropdown-btn" aria-haspopup="true" aria-expanded="false">眾人的智慧 ▾</button>
+            <div class="site-nav__dropdown-menu" role="menu">
+              <a class="site-nav__dropdown-item" href="/wisdom/articles/" role="menuitem">文章</a>
+              <a class="site-nav__dropdown-item" href="/wisdom/videos/" role="menuitem">影片</a>
+              <a class="site-nav__dropdown-item" href="/wisdom/podcasts/" role="menuitem">Podcast</a>
+              <a class="site-nav__dropdown-item" href="/wisdom/lists/" role="menuitem">清單</a>
+              <a class="site-nav__dropdown-item" href="/wisdom/mental-models/" role="menuitem">思維模型</a>
+              <a class="site-nav__dropdown-item" href="/wisdom/methods/" role="menuitem">方法</a>
+              <a class="site-nav__dropdown-item" href="/wisdom/strategies/" role="menuitem">策略</a>
+              <a class="site-nav__dropdown-item" href="/wisdom/templates/" role="menuitem">範本</a>
+            </div>
+          </div>
+          <a class="site-nav__link" href="/about/">關於</a>
+          <a class="site-nav__link" href="/now/">Now Page</a>
+          <form action="https://www.google.com/search" id="search" method="get" target="_blank" class="site-nav__search">
+            <input type="text" name="q" placeholder="搜尋..." class="site-nav__search-input" aria-label="搜尋">
             <input type="hidden" name="sitesearch" value="{{ config.base_url }}">
-            <button type="submit" class="w3-button w3-teal" style="display:inline-block; padding:6px;">
-              <i class="fa fa-search"></i>
-            </button>
+            <button type="submit" class="site-nav__search-btn" aria-label="送出搜尋">&#128269;</button>
           </form>
         </div>
       </nav>
     </header>
-    <main id="root" class="body-zone flex juistify-between flex-1 main-inner">
+    <main id="root" class="body-zone flex justify-between flex-1 main-inner">
       <section class="main flex-1 py">
         {% block content %}
         {% endblock content %}
@@ -145,11 +159,46 @@
     </footer>
     <script>
       document.addEventListener("DOMContentLoaded", function () {
+        // Mark external links
         var links = document.querySelectorAll("a");
         links.forEach(function (link) {
           if (link.hostname !== window.location.hostname && !link.querySelector('img')) {
             link.classList.add("external-link");
           }
+        });
+
+        // Hamburger menu toggle
+        var hamburgerBtn = document.getElementById("hamburger-btn");
+        var mobileNav = document.getElementById("mobile-nav");
+        if (hamburgerBtn && mobileNav) {
+          hamburgerBtn.addEventListener("click", function () {
+            var isOpen = mobileNav.classList.toggle("is-open");
+            hamburgerBtn.classList.toggle("is-open", isOpen);
+            hamburgerBtn.setAttribute("aria-expanded", isOpen ? "true" : "false");
+            mobileNav.setAttribute("aria-hidden", isOpen ? "false" : "true");
+          });
+          // Close menu when a link is clicked
+          mobileNav.querySelectorAll("a").forEach(function (link) {
+            link.addEventListener("click", function () {
+              mobileNav.classList.remove("is-open");
+              hamburgerBtn.classList.remove("is-open");
+              hamburgerBtn.setAttribute("aria-expanded", "false");
+              mobileNav.setAttribute("aria-hidden", "true");
+            });
+          });
+        }
+
+        // Dropdown toggle for mobile
+        var dropdownBtns = document.querySelectorAll(".site-nav__dropdown-btn");
+        dropdownBtns.forEach(function (btn) {
+          btn.addEventListener("click", function () {
+            var menu = btn.nextElementSibling;
+            if (menu) {
+              var isExpanded = btn.getAttribute("aria-expanded") === "true";
+              btn.setAttribute("aria-expanded", !isExpanded ? "true" : "false");
+              menu.style.display = isExpanded ? "" : "block";
+            }
+          });
         });
       });
     </script>

--- a/templates/page.html
+++ b/templates/page.html
@@ -59,8 +59,19 @@
   {% endfor %}
   {% endif %}
 </div>
-<script src="https://utteranc.es/client.js" repo="mickm3n/blog-comment" issue-term="pathname" theme="github-light"
-  crossorigin="anonymous" async></script>
+<script>
+  (function() {
+    var theme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'github-dark' : 'github-light';
+    var s = document.createElement('script');
+    s.src = 'https://utteranc.es/client.js';
+    s.setAttribute('repo', 'mickm3n/blog-comment');
+    s.setAttribute('issue-term', 'pathname');
+    s.setAttribute('theme', theme);
+    s.setAttribute('crossorigin', 'anonymous');
+    s.async = true;
+    document.currentScript.parentNode.insertBefore(s, document.currentScript.nextSibling);
+  })();
+</script>
 {% endblock content %}
 {% block additional_aside %}
 {% if page.toc %}


### PR DESCRIPTION
## Summary
This PR implements a comprehensive dark mode theme system and redesigns the navigation bar with improved mobile responsiveness and accessibility.

## Key Changes

### Theme System
- Added CSS custom properties for light and dark color schemes
- Implemented dark mode via `data-theme="dark"` attribute on `<html>`
- Added automatic dark mode detection using `prefers-color-scheme` media query
- Created `theme-toggle.js` script that:
  - Persists user theme preference to localStorage
  - Applies theme before page paint to prevent flash
  - Syncs Utterances comment iframe theme on toggle
  - Respects system preference when no manual override is set

### Navigation Redesign
- Replaced W3.CSS navbar with custom `.site-nav` component
- Implemented mobile-first responsive design with hamburger menu
- Added theme toggle button in navigation bar
- Improved accessibility with ARIA labels and semantic HTML
- Desktop layout shows horizontal nav links; mobile shows collapsible menu
- Added smooth transitions for theme switching

### Typography & Styling
- Updated font stack to prioritize Noto Sans TC and Noto Serif TC from Google Fonts
- Applied theme variables to inline code, cards, tables, and links
- Updated table styling to use CSS variables for better theme support
- Added filter effects for external link icons in dark mode

### HTML & Template Updates
- Refactored `base.html` navigation from W3.CSS to custom semantic markup
- Added Google Fonts preconnect and stylesheet links
- Moved theme toggle script to run before page paint
- Updated `page.html` to dynamically set Utterances theme based on current mode
- Fixed typo: `juistify-between` → `justify-between`
- Corrected Open Graph image dimensions

### Other Improvements
- Added `defer` attribute to script tags for better performance
- Adjusted main content padding-top to account for fixed navbar (56px)
- Updated sidebar sticky positioning for new navbar height
- Added smooth color transitions on theme switch

https://claude.ai/code/session_01FFSJLDofwURL27Aho5cqaR