### PR TITLE
Unify article background color with main background

### DIFF
--- a/static/site/styles/site.css
+++ b/static/site/styles/site.css
@@ -125,7 +125,7 @@ html {
   --colors-code-background: rgba(39, 133, 184, 0.35);
   --colors-navbar: rgba(14, 30, 54, 1);
   --colors-background: #0f1623;
-  --colors-article: #141c2b;
+  --colors-article: #0f1623;
   --colors-special: rgba(8, 255, 200, 1);
   --colors-header: #1a3356;
   --colors-header-text: #dce4f0;
@@ -157,7 +157,7 @@ html {
     --colors-code-background: rgba(39, 133, 184, 0.35);
     --colors-navbar: rgba(14, 30, 54, 1);
     --colors-background: #0f1623;
-    --colors-article: #141c2b;
+    --colors-article: #0f1623;
     --colors-special: rgba(8, 255, 200, 1);
     --colors-header: #1a3356;
     --colors-header-text: #dce4f0;


### PR DESCRIPTION
## Summary
Updated the article background color to match the main background color, creating a more cohesive visual design by removing the color distinction between article containers and the page background.

## Changes
- Changed `--colors-article` from `#141c2b` to `#0f1623` in both the default theme and dark mode theme
- This aligns the article background with the `--colors-background` value, eliminating the previous subtle contrast

## Details
The article background color was previously slightly lighter than the main background. This change makes articles blend seamlessly with the page background, likely improving visual consistency and reducing visual hierarchy separation between article content and the surrounding page.

https://claude.ai/code/session_01E7R5wX3P7bTqYJMmRAbnMw