### PR TITLE
升級 Zola 至 0.22.1 並修正 highlight config 語法

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 public/
 static/processed_images/
+static/giallo.css
 .venv/
 post_embedding_cache.pkl
 __pycache__

--- a/config.toml
+++ b/config.toml
@@ -16,12 +16,12 @@ taxonomies = [
 ]
 
 [markdown]
-# Whether to do syntax highlighting
-# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
-highlight_theme = "css"
-highlight_code = true
 external_links_target_blank = true
 external_links_no_referrer = true
+
+[markdown.highlighting]
+style = "class"
+theme = "github-dark"
 
 [slugify]
 paths = "off"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "zola build"
 
 [build.environment]
-ZOLA_VERSION = "0.19.2"
+ZOLA_VERSION = "0.22.1"
 
 # 正式環境 - 使用 config.toml 中設定的 base_url
 [context.production]


### PR DESCRIPTION
## Summary

- `highlight_code` / `highlight_theme` 在 Zola 0.22 移除，改為 `[markdown.highlighting]` 子區塊
- Netlify `ZOLA_VERSION` 從 `0.19.2` 升至 `0.22.1`

## Changes

**config.toml**
```toml
# Before
highlight_theme = "css"
highlight_code = true

# After
[markdown.highlighting]
style = "class"
theme = "github-dark"
```

**netlify.toml**
```toml
ZOLA_VERSION = "0.22.1"
```

## Test plan

- [x] `zola build` 本機通過（0.22.1）

🤖 Generated with [Claude Code](https://claude.com/claude-code)