### PR TITLE
新增 tmux 行動裝置最小設定（mouse on、escape-time、history-limit）

### DIFF
--- a/content/blog/gym-development-tailscale-tmux-termius/index.md
+++ b/content/blog/gym-development-tailscale-tmux-termius/index.md
@@ -96,7 +96,26 @@ macOS 預設沒有開 SSH，需要手動啟用：
 brew install tmux
 ```
 
-### 4. 確認 Tailscale IP
+### 4. 設定 tmux（行動裝置優化）
+
+安裝完後建議加一份最小設定，讓 Termius 在手機上操作更順：
+
+```bash
+# ~/.tmux.conf
+set -g mouse on           # 觸控捲動與點選 pane（最重要）
+set -sg escape-time 0     # 減少輸入延遲
+set -g history-limit 10000  # 增加捲動記錄長度
+```
+
+其中 `mouse on` 是關鍵：沒有這行的話，在 Termius 上滑動畫面不會捲動輸出，而是會循環切換歷史指令，非常難用。
+
+設定完後執行一次讓設定生效：
+
+```bash
+tmux source-file ~/.tmux.conf
+```
+
+### 5. 確認 Tailscale IP
 
 可以在狀態列看到
 

--- a/content/blog/gym-development-tailscale-tmux-termius/index.md
+++ b/content/blog/gym-development-tailscale-tmux-termius/index.md
@@ -119,7 +119,7 @@ tmux source-file ~/.tmux.conf
 
 可以在狀態列看到
 
-![](tailscale.png)
+![](tailscale.webp)
 
 在 Mac Mini 上執行：
 


### PR DESCRIPTION
在安裝 tmux 後補充必要的 .tmux.conf 設定，說明 mouse on 是 Termius
手機操作不可缺少的關鍵設定，沒有它滑動不會捲動輸出而是切換歷史指令。

https://claude.ai/code/session_01S8vZNhRCrfPuKPpaydwFiS